### PR TITLE
Fixed starting playing

### DIFF
--- a/mpd.coffee
+++ b/mpd.coffee
@@ -115,7 +115,7 @@ module.exports = (env) ->
     getCurrentTitle: () -> Promise.resolve(@_currentTitle)
     getCurrentArtist: () -> Promise.resolve(@_currentTitle)
     getVolume: ()  -> Promise.resolve(@_volume)
-    play: () -> @_sendCommandAction('pause', '0')
+    play: () -> @_sendCommandAction('play')
     pause: () -> @_sendCommandAction('pause', '1')
     previous: () -> @_sendCommandAction('previous')
     next: () -> @_sendCommandAction('next')


### PR DESCRIPTION
When nothing was playing on mpd you can't resume it with "pause 0". You
have to start playing with "play".
Don't know if you can use "play" to resume playing when paused befor or
if you have to use "pause 0"